### PR TITLE
meta: switch PR template change types to match convential commit suggestions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,13 +8,14 @@
 
 <!--- What types of changes does your code introduce? -->
 <!--- Put an `x` in all the boxes that apply -->
-- [ ] Core
 - [ ] Bugfix
 - [ ] New feature
-- [ ] Enhancement/optimization
-- [ ] Keyboard (addition or update)
-- [ ] Keymap/layout/userspace (addition or update)
+- [ ] Performance/Optimization
 - [ ] Documentation
+- [ ] Chore
+- [ ] Pipelines/Tooling
+- [ ] Meta
+- [ ] Style/Refactor
 
 ## Related Issues
 


### PR DESCRIPTION
<!--- Add a brief summary of your changes in the title above -->

## Description

The current template has cruft I forgot to delete from the qmk repo's.
Changed the available types (see below) to match suggestions from https://conventionalcommits.org/.

## Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Performance/Optimization
- [ ] Documentation
- [ ] Chore
- [ ] Pipelines/Tooling
- [x] Meta
- [ ] Style/Refactor

## Checklist

<!--- Review the folliwng items and consider if they apply -->
<!--- Put an `x` in any applicable boxes reach out if you -->
- [ ] Unit tests are passing as of the last commit in this branch
- [ ] Integration tests are passing as of the last commit in this branch
- [x] I have read and agree with the [guidelines
  document](https://github.com/loksonarius/mcsm/blob/main/GUIDELINES.md)
- [ ] My changes requires a change to the documentation
- [ ] My additions and edits are covered by tests

<!--- If you're unsure about any of these, please don't hesitate to ask! -->
